### PR TITLE
test: unit case sensitive in a functional test

### DIFF
--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -252,25 +252,25 @@ class WalletTest(BitcoinTestFramework):
         node_0_bal += Decimal('10')
         assert_equal(self.nodes[0].getbalance(), node_0_bal)
 
-        # Sendmany with explicit fee (SAT/B)
+        # Sendmany with explicit fee (sat/B)
         # Throw if no conf_target provided
         assert_raises_rpc_error(-8, "Selected estimate_mode requires a fee rate",
             self.nodes[2].sendmany,
             amounts={ address: 10 },
-            estimate_mode='sat/b')
+            estimate_mode='sat/B')
         # Throw if negative feerate
         assert_raises_rpc_error(-3, "Amount out of range",
             self.nodes[2].sendmany,
             amounts={ address: 10 },
             conf_target=-1,
-            estimate_mode='sat/b')
+            estimate_mode='sat/B')
         fee_sat_per_b = 2
         fee_per_kb = fee_sat_per_b / 100000.0
         explicit_fee_per_byte = Decimal(fee_per_kb) / 1000
         txid = self.nodes[2].sendmany(
             amounts={ address: 10 },
             conf_target=fee_sat_per_b,
-            estimate_mode='sAT/b',
+            estimate_mode='sat/B',
         )
         self.nodes[2].generate(1)
         self.sync_all(self.nodes[0:3])
@@ -447,9 +447,9 @@ class WalletTest(BitcoinTestFramework):
             fee = prebalance - postbalance - Decimal('1')
             assert_fee_amount(fee, tx_size, Decimal('0.00002500'))
 
-            # send with explicit sat/b fee
+            # send with explicit sat/B fee
             self.sync_all(self.nodes[0:3])
-            self.log.info("test explicit fee (sendtoaddress as sat/b)")
+            self.log.info("test explicit fee (sendtoaddress as sat/B)")
             self.nodes[0].generate(1)
             prebalance = self.nodes[2].getbalance()
             assert prebalance > 2
@@ -459,19 +459,19 @@ class WalletTest(BitcoinTestFramework):
                 self.nodes[2].sendtoaddress,
                 address=address,
                 amount=1.0,
-                estimate_mode='SAT/b')
+                estimate_mode='sat/B')
             # Throw if negative feerate
             assert_raises_rpc_error(-3, "Amount out of range",
                 self.nodes[2].sendtoaddress,
                 address=address,
                 amount=1.0,
                 conf_target=-1,
-                estimate_mode='SAT/b')
+                estimate_mode='sat/B')
             txid = self.nodes[2].sendtoaddress(
                 address=address,
                 amount=1.0,
                 conf_target=2,
-                estimate_mode='SAT/B',
+                estimate_mode='sat/B',
             )
             tx_size = self.get_vsize(self.nodes[2].gettransaction(txid)['hex'])
             self.sync_all(self.nodes[0:3])

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -231,19 +231,19 @@ class WalletTest(BitcoinTestFramework):
         assert_raises_rpc_error(-8, "Selected estimate_mode requires a fee rate",
             self.nodes[2].sendmany,
             amounts={ address: 10 },
-            estimate_mode='bTc/kB')
+            estimate_mode='BTC/kB')
         # Throw if negative feerate
         assert_raises_rpc_error(-3, "Amount out of range",
             self.nodes[2].sendmany,
             amounts={ address: 10 },
             conf_target=-1,
-            estimate_mode='bTc/kB')
+            estimate_mode='BTC/kB')
         fee_per_kb = 0.0002500
         explicit_fee_per_byte = Decimal(fee_per_kb) / 1000
         txid = self.nodes[2].sendmany(
             amounts={ address: 10 },
             conf_target=fee_per_kb,
-            estimate_mode='bTc/kB',
+            estimate_mode='BTC/kB',
         )
         self.nodes[2].generate(1)
         self.sync_all(self.nodes[0:3])
@@ -413,8 +413,8 @@ class WalletTest(BitcoinTestFramework):
             self.nodes[0].generate(1)
             self.sync_all(self.nodes[0:3])
 
-            # send with explicit btc/kb fee
-            self.log.info("test explicit fee (sendtoaddress as btc/kb)")
+            # send with explicit BTC/kB fee
+            self.log.info("test explicit fee (sendtoaddress as BTC/kB)")
             self.nodes[0].generate(1)
             self.sync_all(self.nodes[0:3])
             prebalance = self.nodes[2].getbalance()
@@ -425,19 +425,19 @@ class WalletTest(BitcoinTestFramework):
                 self.nodes[2].sendtoaddress,
                 address=address,
                 amount=1.0,
-                estimate_mode='BTc/Kb')
+                estimate_mode='BTC/kB')
             # Throw if negative feerate
             assert_raises_rpc_error(-3, "Amount out of range",
                 self.nodes[2].sendtoaddress,
                 address=address,
                 amount=1.0,
                 conf_target=-1,
-                estimate_mode='btc/kb')
+                estimate_mode='BTC/kB')
             txid = self.nodes[2].sendtoaddress(
                 address=address,
                 amount=1.0,
                 conf_target=0.00002500,
-                estimate_mode='btc/kb',
+                estimate_mode='BTC/kB',
             )
             tx_size = self.get_vsize(self.nodes[2].gettransaction(txid)['hex'])
             self.sync_all(self.nodes[0:3])


### PR DESCRIPTION
I found some confused case sensitive in `BTC` and `kB`. It doesn't change the test result.

before:
```
bTc/kB
btc/kb
BTc/Kb
```

after:
```
BTC/kB
```

test result:
```bash
$ ./test/functional/test_runner.py --jobs=4 --loglevel=DEBUG --previous-releases --coverage --extended wallet_basic.py

Temporary test directory at /tmp/test_runner_₿_🏃_20200929_224115
Running Unit Tests for Test Framework Modules
.......
----------------------------------------------------------------------
Ran 7 tests in 0.008s

OK
Initializing coverage directory at /tmp/coveragevbx7unjc
Remaining jobs: [wallet_basic.py]
1/1 - wallet_basic.py passed, Duration: 32 s                   

TEST            | STATUS    | DURATION

wallet_basic.py | ✓ Passed  | 32 s

ALL             | ✓ Passed  | 32 s (accumulated) 
Runtime: 32 s
```